### PR TITLE
Ignore pty path error on Linux

### DIFF
--- a/ftests/test_client.go
+++ b/ftests/test_client.go
@@ -21,7 +21,7 @@ func testClientAttachHostWithSameCommand(t *testing.T, testServer TestServer) {
 	adminSocketFile := filepath.Join(adminSockDir, "upterm.sock")
 
 	h := &Host{
-		Command:                  []string{"bash", "-c", "PS1='' bash"},
+		Command:                  []string{"bash", "-c", "PS1='' bash --norc"},
 		PrivateKeys:              []string{HostPrivateKey},
 		AdminSocketFile:          adminSocketFile,
 		PermittedClientPublicKey: ClientPublicKeyContent,
@@ -106,8 +106,8 @@ func testClientAttachHostWithDifferentCommand(t *testing.T, testServer TestServe
 	adminSocketFile := filepath.Join(adminSockDir, "upterm.sock")
 
 	h := &Host{
-		Command:                  []string{"bash", "-c", "PS1='' bash"},
-		ForceCommand:             []string{"bash", "-c", "PS1='' bash"},
+		Command:                  []string{"bash", "-c", "PS1='' bash --norc"},
+		ForceCommand:             []string{"bash", "-c", "PS1='' bash --norc"},
 		PrivateKeys:              []string{HostPrivateKey},
 		AdminSocketFile:          adminSocketFile,
 		PermittedClientPublicKey: ClientPublicKeyContent,

--- a/ftests/test_host.go
+++ b/ftests/test_host.go
@@ -12,12 +12,12 @@ import (
 func testHostSessionCreatedCallback(t *testing.T, testServer TestServer) {
 	sessionID := xid.New().String()
 	h := &Host{
-		Command:      []string{"bash"},
+		Command:      []string{"bash", "--norc"},
 		ForceCommand: []string{"vim"},
 		PrivateKeys:  []string{HostPrivateKey},
 		SessionID:    sessionID,
 		SessionCreatedCallback: func(session *models.APIGetSessionResponse) error {
-			if want, got := []string{"bash"}, session.Command; !cmp.Equal(want, got) {
+			if want, got := []string{"bash", "--norc"}, session.Command; !cmp.Equal(want, got) {
 				t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
 			}
 			if want, got := []string{"vim"}, session.ForceCommand; !cmp.Equal(want, got) {

--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -124,7 +124,7 @@ func (c *command) Run() error {
 		ctx, cancel := context.WithCancel(c.ctx)
 		g.Add(func() error {
 			_, err := io.Copy(c.writers, uio.NewContextReader(ctx, c.ptmx))
-			return err
+			return ptyError(err)
 		}, func(err error) {
 			c.writers.Remove(os.Stdout)
 			cancel()

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -176,7 +176,7 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 			ctx, cancel := context.WithCancel(h.ctx)
 			g.Add(func() error {
 				_, err := io.Copy(sess, uio.NewContextReader(ctx, ptmx))
-				return err
+				return ptyError(err)
 			}, func(err error) {
 				cancel()
 			})


### PR DESCRIPTION
Linux kernel return EIO when attempting to read from a master pseudo
terminal which no longer has an open slave. So ignore error here.
See https://github.com/creack/pty/issues/21