### PR TITLE
WebSocketProxy routes to SSHProxy

### DIFF
--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -13,7 +13,7 @@ import (
 
 type SSHProxy struct {
 	HostSigners     []ssh.Signer
-	ConnDialer      connDialer
+	ConnDialer      ConnDialer
 	Logger          log.FieldLogger
 	MetricsProvider provider.Provider
 

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -30,9 +30,9 @@ func Test_SSHProxy_findUpstream(t *testing.T) {
 
 	proxyAddr := proxyLn.Addr().String()
 	cd := connDialer{
-		NodeAddr:         proxyAddr,
-		DialNodeAddrFunc: func(id api.Identifier) (net.Conn, error) { return net.Dial("tcp", id.NodeAddr) },
-		Logger:           logger,
+		NodeAddr:        proxyAddr,
+		NeighbourDialer: tcpConnDialer{},
+		Logger:          logger,
 	}
 	proxy := &SSHProxy{
 		HostSigners:     []ssh.Signer{signer},

--- a/server/wsproxy.go
+++ b/server/wsproxy.go
@@ -18,7 +18,7 @@ import (
 )
 
 type WebSocketProxy struct {
-	ConnDialer connDialer
+	ConnDialer ConnDialer
 	Logger     log.FieldLogger
 
 	srv *http.Server
@@ -76,7 +76,7 @@ var upgrader = websocket.Upgrader{
 }
 
 type wsHandler struct {
-	ConnDialer connDialer
+	ConnDialer ConnDialer
 	Logger     log.FieldLogger
 }
 


### PR DESCRIPTION
Requests to WebSocketProxy are routed to SSHProxy so that SSHProxy
always terminate ssh connection for a consistent authenticate machanism.