### PR TITLE
Add --read-only flag

### DIFF
--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -25,6 +25,7 @@ var (
 	flagForceCommand   string
 	flagPrivateKeys    []string
 	flagAuthorizedKeys string
+	flagReadOnly       bool
 )
 
 func hostCmd() *cobra.Command {
@@ -54,6 +55,7 @@ func hostCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&flagForceCommand, "force-command", "f", "", "force execution of a command and attach its input/output to client's.")
 	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", nil, "private key for public key authentication against the upterm server (required).")
 	cmd.PersistentFlags().StringVarP(&flagAuthorizedKeys, "authorized-key", "a", "", "an authorized_keys file that lists public keys that are permitted to connect.")
+	cmd.PersistentFlags().BoolVarP(&flagReadOnly, "read-only", "r", false, "host a read-only session. Clients won't be able to interact.")
 
 	return cmd
 }
@@ -139,6 +141,7 @@ func shareRunE(c *cobra.Command, args []string) error {
 		KeepAliveDuration:      50 * time.Second, // nlb is 350 sec & heroku router is 55 sec
 		SessionCreatedCallback: displaySessionCallback,
 		Logger:                 log.New(),
+		ReadOnly:               flagReadOnly,
 	}
 
 	return h.Run(context.Background())

--- a/ftests/client_test.go
+++ b/ftests/client_test.go
@@ -2,6 +2,7 @@ package ftests
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,6 +239,110 @@ func testClientAttachHostWithDifferentCommand(t *testing.T, hostURL string, node
 	if want, got := "hello", scan(hostScanner); want != got {
 		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
 	}
+}
+
+func testClientAttachReadOnly(t *testing.T, hostURL, nodeAddr string) {
+	adminSockDir, err := newAdminSocketDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(adminSockDir)
+
+	adminSocketFile := filepath.Join(adminSockDir, "upterm.sock")
+
+	h := &Host{
+		Command:                  []string{"bash", "-c", "PS1='' bash --norc"},
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+		ReadOnly:                 true,
+	}
+	if err := h.Share(hostURL); err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	// verify admin server
+	adminClient := host.AdminClient(adminSocketFile)
+	resp, err := adminClient.GetSession(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := resp.GetPayload()
+	if want, got := h.SessionID, session.SessionID; want != got {
+		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
+	}
+	if want, got := hostURL, session.Host; want != got {
+		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
+	}
+	if want, got := nodeAddr, session.NodeAddr; want != got {
+		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
+	}
+
+	// verify input/output
+	hostInputCh, hostOutputCh := h.InputOutput()
+	hostScanner := scanner(hostOutputCh)
+
+	c := &Client{
+		PrivateKeys: []string{ClientPrivateKey},
+	}
+	if err := c.Join(session, hostURL); err != nil {
+		t.Fatal(err)
+	}
+
+	remoteInputCh, remoteOutputCh := c.InputOutput()
+	remoteScanner := scanner(remoteOutputCh)
+
+	// client output
+	// client should get "welcome message"
+	// \n
+	// === Attached to read-only session ===
+	// \n
+	if want, got := "", scan(remoteScanner); want != got {
+		t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+	}
+	if want, got := "=== Attached to read-only session ===", scan(remoteScanner); want != got {
+		t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+	}
+	if want, got := "", scan(remoteScanner); want != got {
+		t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+	}
+
+	// host input should still work
+	hostInputCh <- "echo hello"
+	if want, got := "echo hello", scan(hostScanner); want != got {
+		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
+	}
+	if want, got := "hello", scan(hostScanner); want != got {
+		t.Fatalf("want=%s got=%s:\n%s", want, got, cmp.Diff(want, got))
+	}
+
+	// client input should be disabled
+	remoteInputCh <- "echo hello again"
+	// client should read what was sent by hostInputCh and not what was sent on remoteInputCh
+	if want, got := "echo hello", scan(remoteScanner); want != got {
+		t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+	}
+
+	// host output
+	// host should link to remote with the same input/output
+	// scan will timeout as there shouldn't be anything to scan
+	// client didn't insert anything
+	go func() {
+		if want, got := "", scan(hostScanner); want != got {
+			t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+		}
+		if want, got := "hello again", scan(hostScanner); want != got {
+			t.Fatalf("want=%q got=%q:\n%s", want, got, cmp.Diff(want, got))
+		}
+	}()
+
+	select {
+	case <-time.After(time.Second * 1):
+		log.Println("Timeout hit..")
+		return
+	}
+
 }
 
 func newAdminSocketDir() (string, error) {

--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -91,6 +91,7 @@ func Test_ftest(t *testing.T) {
 		testClientNonExistingSession,
 		testClientAttachHostWithSameCommand,
 		testClientAttachHostWithDifferentCommand,
+		testClientAttachReadOnly,
 		testHostFailToShareWithoutPrivateKey,
 		testHostSessionCreatedCallback,
 	}
@@ -216,11 +217,11 @@ type Host struct {
 	AdminSocketFile          string
 	SessionCreatedCallback   func(*models.APIGetSessionResponse) error
 	PermittedClientPublicKey string
-
-	inputCh  chan string
-	outputCh chan string
-	ctx      context.Context
-	cancel   func()
+	ReadOnly                 bool
+	inputCh                  chan string
+	outputCh                 chan string
+	ctx                      context.Context
+	cancel                   func()
 }
 
 func (c *Host) Close() {
@@ -291,6 +292,7 @@ func (c *Host) Share(url string) error {
 		Stdin:                  stdinr,
 		Stdout:                 stdoutw,
 		SessionID:              c.SessionID,
+		ReadOnly:               c.ReadOnly,
 	}
 
 	errCh := make(chan error)

--- a/host/host.go
+++ b/host/host.go
@@ -31,6 +31,7 @@ type Host struct {
 	Logger                 log.FieldLogger
 	Stdin                  *os.File
 	Stdout                 *os.File
+	ReadOnly               bool
 }
 
 func (c *Host) createAdminSocketDir(sessionID string) (string, error) {
@@ -124,6 +125,7 @@ func (c *Host) Run(ctx context.Context) error {
 			Stdin:             c.Stdin,
 			Stdout:            c.Stdout,
 			Logger:            c.Logger,
+			ReadOnly:          c.ReadOnly,
 		}
 		g.Add(func() error {
 			return sshServer.ServeWithContext(ctx, rt.Listener())


### PR DESCRIPTION
This adds a read-only flag that allows hosting an upterm session that is read-only. Clients can connect as normal but won't be able to interact with the session. All other functionality remains as is, this simply doesn't attach the stdin of the client to the session pty.