### PR TITLE
Ignore bad file descriptor error when resizing window

### DIFF
--- a/host/internal/event.go
+++ b/host/internal/event.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/jingweno/upterm/upterm"
 	"github.com/olebedev/emitter"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	errBadFileDescriptor = "bad file descriptor"
 )
 
 type terminal struct {
@@ -93,7 +98,7 @@ func (t terminalEventHandler) handleWindowChanged(evt emitter.Event, m map[io.Re
 		m[pty] = ts
 	}
 	ts[tt.ID] = tt
-	if err := resizeWindow(pty, ts); err != nil {
+	if err := resizeWindow(pty, ts); err != nil && !strings.Contains(err.Error(), errBadFileDescriptor) {
 		return fmt.Errorf("error resizing window: %w", err)
 	}
 


### PR DESCRIPTION
When client drops with a `kill`, host reports the following errors due
to pty is closed:

```
ERRO[0015] error handling window changed                 error="error resizing window: bad file descriptor"
```